### PR TITLE
Rename expiration to ttl and some cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- START: Include on https://convex.dev/components -->
 
-Sometimes your app needs to fetch information from a third-party API that is slow or costs money. Caching can help! This is a Convex component that can cache the results of expensive functions and set an optional expiration. Expired entries are cleaned up via a cron job once a day. The cache key is the `ActionCache`'s name (defaults to function name) and the arguments to the action that generates the cache values.
+Sometimes your app needs to fetch information from a third-party API that is slow or costs money. Caching can help! This is a Convex component that can cache the results of expensive functions and set an optional TTL. Expired entries are cleaned up via a cron job once a day. The cache key is the `ActionCache`'s name (defaults to function name) and the arguments to the action that generates the cache values.
 
 ```ts
 import { Client } from "@convex-dev/cache";
@@ -67,9 +67,9 @@ export default app;
 Finally, create a new `ActionCache` with optional name and expiration within your Convex project, and point it to the installed component.
 
 - The `name` field can be used for identifying the function or version being used to create the values in the cache and can also be used for grouping entries to remove.
-- The `expiration` field determines how long the cache entries are valid, in milliseconds.
-  - If no `expiration` is provided, the cache entries are kept indefinitely.
-  - If an `expiration` is provided, expired cache entries are deleted when they are retrieved and in a daily cron job.
+- The `ttl` (Time-To-Live) field determines how long the cache entries are valid, in milliseconds.
+  - If no `ttl` is provided, the cache entries are kept indefinitely.
+  - If an `ttl` is provided, expired cache entries are deleted when they are retrieved and in a daily cron job.
 
 ```ts
 import { ActionCache } from "@convex-dev/cache";
@@ -78,7 +78,7 @@ import { components } from "./_generated/api";
 const cache = new ActionCache(components.actionCache, {
   action: internal.example.myExpensiveAction,
   name: "myExpensiveActionV1",
-  expiration: 1000 * 60 * 60 * 24 * 7, // 7 days
+  ttl: 1000 * 60 * 60 * 24 * 7, // 7 days
 });
 ```
 

--- a/example/convex/_generated/api.d.ts
+++ b/example/convex/_generated/api.d.ts
@@ -47,14 +47,14 @@ export declare const components: {
       get: FunctionReference<
         "mutation",
         "internal",
-        { args: any; expiration: number | null; name: string },
+        { args: any; name: string },
         any | null
       >;
       put: FunctionReference<
         "mutation",
         "internal",
-        { args: any; expiration: number | null; name: string; value: any },
-        any
+        { args: any; name: string; ttl: number | null; value: any },
+        null
       >;
     };
     crons: {
@@ -69,7 +69,7 @@ export declare const components: {
       fetch: FunctionReference<
         "action",
         "internal",
-        { args: any; expiration: number | null; fn: string; name: string },
+        { args: any; fn: string; name: string; ttl: number | null },
         any
       >;
       remove: FunctionReference<

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -103,10 +103,12 @@ export class ActionCache<
   /**
    * Clear all values in the cache.
    * @param ctx - The Convex mutation context.
+   * @param before - (optional) Remove all values created before this timestamp.
+   * Defaults to now (all values).
    * @returns
    */
-  async removeAll(ctx: RunMutationCtx) {
-    return ctx.runMutation(this.component.public.removeAll, {});
+  async removeAll(ctx: RunMutationCtx, before?: number) {
+    return ctx.runMutation(this.component.public.removeAll, { before });
   }
 }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -28,8 +28,8 @@ export interface ActionCacheConfig<
   /**
    * The maximum number of milliseconds this cache entry is valid for.
    * If not provided, the cache entry will be stored indefinitely.
-   * This default can be overriden on a per-entry basis.
-   * Note: It may be evicted from the cache before this time.
+   * This default can be overriden on a per-entry basis by calling `fetch`
+   * with the `ttl` option.
    */
   ttl?: number;
 }

--- a/src/component/_generated/api.d.ts
+++ b/src/component/_generated/api.d.ts
@@ -37,14 +37,14 @@ export type Mounts = {
     get: FunctionReference<
       "mutation",
       "public",
-      { args: any; expiration: number | null; name: string },
+      { args: any; name: string },
       any | null
     >;
     put: FunctionReference<
       "mutation",
       "public",
-      { args: any; expiration: number | null; name: string; value: any },
-      any
+      { args: any; name: string; ttl: number | null; value: any },
+      null
     >;
   };
   crons: {
@@ -59,7 +59,7 @@ export type Mounts = {
     fetch: FunctionReference<
       "action",
       "public",
-      { args: any; expiration: number | null; fn: string; name: string },
+      { args: any; fn: string; name: string; ttl: number | null },
       any
     >;
     remove: FunctionReference<

--- a/src/component/cache.ts
+++ b/src/component/cache.ts
@@ -49,6 +49,7 @@ export const put = mutation({
     value: v.any(),
     ttl: v.union(v.float64(), v.null()),
   },
+  returns: v.null(),
   handler: async (ctx, args) => {
     const existing = await getInner(ctx, args);
     const { ttl, ...rest } = args;

--- a/src/component/cache.ts
+++ b/src/component/cache.ts
@@ -13,7 +13,7 @@ export const get = mutation({
   args: {
     name: v.string(),
     args: v.any(),
-    expiration: v.union(v.float64(), v.null()),
+    ttl: v.union(v.float64(), v.null()),
   },
   returns: v.union(v.any(), v.null()),
   handler: getInner,
@@ -21,20 +21,18 @@ export const get = mutation({
 
 async function getInner(
   ctx: MutationCtx,
-  args: { name: string; args: unknown; expiration: number | null }
+  args: { name: string; args: unknown; ttl: number | null }
 ) {
   const match = await ctx.db
     .query("values")
     .withIndex("key", (q) => q.eq("name", args.name).eq("args", args.args))
     .unique();
   if (!match) return null;
-  const expirationDoc =
-    match.expirationId && (await ctx.db.get(match.expirationId));
+  const metadataDoc = match.metadataId && (await ctx.db.get(match.metadataId));
   // Invalidate expired values
-  if (expirationDoc && expirationDoc.expiresAt <= Date.now()) {
-    console.log("deleting old entry");
+  if (metadataDoc && metadataDoc.expiresAt <= Date.now()) {
     await ctx.db.delete(match._id);
-    await ctx.db.delete(expirationDoc._id);
+    await ctx.db.delete(metadataDoc._id);
     return null;
   }
   return match;
@@ -42,31 +40,44 @@ async function getInner(
 
 /**
  * Put a value into the cache. Updates the value if it already exists.
- * If expiration is non-null, it will set the expiration to that number of milliseconds from now.
- * If expiration is null, it will never expire.
+ * If ttl is non-null, it will set the ttl to that number of milliseconds from now.
+ * If ttl is null, it will never expire.
  */
 export const put = mutation({
   args: {
     name: v.string(),
     args: v.any(),
     value: v.any(),
-    expiration: v.union(v.float64(), v.null()),
+    ttl: v.union(v.float64(), v.null()),
   },
   handler: async (ctx, args) => {
     const existing = await getInner(ctx, args);
+    const { ttl, ...rest } = args;
     if (existing) {
       if (existing.value !== args.value) {
-        await ctx.db.patch(existing._id, { value: args.value });
+        await ctx.db.patch(existing._id, {
+          value: args.value,
+          metadataId: ttl === null ? undefined : existing.metadataId,
+        });
+        if (existing.metadataId) {
+          if (ttl === null) {
+            await ctx.db.delete(existing.metadataId);
+          } else {
+            await ctx.db.patch(existing.metadataId, {
+              expiresAt: Date.now() + ttl,
+            });
+          }
+        }
       }
     } else {
-      const { expiration, ...rest } = args;
       const valueId = await ctx.db.insert("values", rest);
-      if (expiration == null) return;
-      const expirationId = await ctx.db.insert("expirations", {
-        valueId,
-        expiresAt: Date.now() + expiration,
-      });
-      await ctx.db.patch(valueId, { expirationId });
+      if (ttl !== null) {
+        const metadataId = await ctx.db.insert("metadata", {
+          valueId,
+          expiresAt: Date.now() + ttl,
+        });
+        await ctx.db.patch(valueId, { metadataId });
+      }
     }
   },
 });

--- a/src/component/cache.ts
+++ b/src/component/cache.ts
@@ -13,7 +13,6 @@ export const get = mutation({
   args: {
     name: v.string(),
     args: v.any(),
-    ttl: v.union(v.float64(), v.null()),
   },
   returns: v.union(v.any(), v.null()),
   handler: getInner,
@@ -21,7 +20,7 @@ export const get = mutation({
 
 async function getInner(
   ctx: MutationCtx,
-  args: { name: string; args: unknown; ttl: number | null }
+  args: { name: string; args: unknown }
 ) {
   const match = await ctx.db
     .query("values")

--- a/src/component/component.test.ts
+++ b/src/component/component.test.ts
@@ -42,7 +42,7 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     await t.run(async (ctx) => {
       const metadata = await ctx.db.query("metadata").collect();
       expect(metadata).toHaveLength(1);
-      expect(metadata[0].expiresAt < Date.now() + 1000);
+      expect(metadata[0].expiresAt).toBeLessThanOrEqual(Date.now() + 1000);
     });
     const result = await t.mutation(api.cache.get, {
       name: "test",
@@ -50,6 +50,76 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     });
     expect(result).not.toBeNull();
     expect(result?.value).toEqual(value);
+  }
+);
+
+fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
+  "Put with new value updates ttl",
+  async ({ key, value }) => {
+    const t = convexTest(schema, modules);
+    await t.mutation(api.cache.put, {
+      name: "test",
+      args: { key },
+      value,
+      ttl: null,
+    });
+    const newValue = [...value, 1];
+
+    // add a ttl
+    await t.mutation(api.cache.put, {
+      name: "test",
+      args: { key },
+      value: newValue,
+      ttl: 1000,
+    });
+    await t.run(async (ctx) => {
+      const metadata = await ctx.db.query("metadata").collect();
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0].expiresAt).toBeLessThanOrEqual(Date.now() + 1000);
+    });
+    const result = await t.mutation(api.cache.get, {
+      name: "test",
+      args: { key },
+    });
+    expect(result).not.toBeNull();
+    expect(result?.value).toEqual(newValue);
+
+    // now update the ttl
+    await t.mutation(api.cache.put, {
+      name: "test",
+      args: { key },
+      value,
+      ttl: 10000,
+    });
+    await t.run(async (ctx) => {
+      const metadata = await ctx.db.query("metadata").collect();
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0].expiresAt).toBeLessThanOrEqual(Date.now() + 10000);
+    });
+    const result2 = await t.mutation(api.cache.get, {
+      name: "test",
+      args: { key },
+    });
+    expect(result2).not.toBeNull();
+    expect(result2?.value).toEqual(value);
+
+    // remove the ttl again
+    await t.mutation(api.cache.put, {
+      name: "test",
+      args: { key },
+      value: newValue,
+      ttl: null,
+    });
+    await t.run(async (ctx) => {
+      const metadata = await ctx.db.query("metadata").collect();
+      expect(metadata).toHaveLength(0);
+    });
+    const result3 = await t.mutation(api.cache.get, {
+      name: "test",
+      args: { key },
+    });
+    expect(result3).not.toBeNull();
+    expect(result3?.value).toEqual(newValue);
   }
 );
 

--- a/src/component/component.test.ts
+++ b/src/component/component.test.ts
@@ -3,7 +3,6 @@ import schema from "./schema";
 import { expect } from "vitest";
 import { api } from "./_generated/api";
 import { modules } from "./setup.test";
-import { DAY } from "./cache";
 import { test as fcTest, fc } from "@fast-check/vitest";
 
 fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
@@ -13,19 +12,19 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     const empty = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      expiration: null,
+      ttl: null,
     });
     expect(empty).toBeNull();
     await t.mutation(api.cache.put, {
       name: "test",
       args: { key },
       value,
-      expiration: 1000,
+      ttl: 1000,
     });
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      expiration: null,
+      ttl: null,
     });
     expect(result).not.toBeNull();
     expect(result?.value).toEqual(value);
@@ -33,24 +32,24 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
 );
 
 fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
-  "Put with expiration works",
+  "Put with ttl works",
   async ({ key, value }) => {
     const t = convexTest(schema, modules);
     await t.mutation(api.cache.put, {
       name: "test",
       args: { key },
       value,
-      expiration: 1000,
+      ttl: 1000,
     });
     await t.run(async (ctx) => {
-      const expirations = await ctx.db.query("expirations").collect();
-      expect(expirations).toHaveLength(1);
-      expect(expirations[0].expiresAt < Date.now() + 1000);
+      const metadata = await ctx.db.query("metadata").collect();
+      expect(metadata).toHaveLength(1);
+      expect(metadata[0].expiresAt < Date.now() + 1000);
     });
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      expiration: null,
+      ttl: null,
     });
     expect(result).not.toBeNull();
     expect(result?.value).toEqual(value);
@@ -58,23 +57,23 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
 );
 
 fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
-  "Getting with a expiration on cache hit does not update previous indefinite expiration",
+  "Getting with a ttl on cache hit does not update previous indefinite ttl",
   async ({ key, value }) => {
     const t = convexTest(schema, modules);
     await t.mutation(api.cache.put, {
       name: "test",
       args: { key },
       value,
-      expiration: null,
+      ttl: null,
     });
     await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      expiration: 1000,
+      ttl: 1000,
     });
     await t.run(async (ctx) => {
-      const expirations = await ctx.db.query("expirations").collect();
-      expect(expirations).toHaveLength(0);
+      const metadata = await ctx.db.query("metadata").collect();
+      expect(metadata).toHaveLength(0);
     });
   }
 );
@@ -87,12 +86,12 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
       name: "test",
       args: { key },
       value,
-      expiration: 0,
+      ttl: 0,
     });
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      expiration: null,
+      ttl: null,
     });
     expect(result).toBeNull();
   }

--- a/src/component/component.test.ts
+++ b/src/component/component.test.ts
@@ -12,7 +12,6 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     const empty = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      ttl: null,
     });
     expect(empty).toBeNull();
     await t.mutation(api.cache.put, {
@@ -24,7 +23,6 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      ttl: null,
     });
     expect(result).not.toBeNull();
     expect(result?.value).toEqual(value);
@@ -49,7 +47,6 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      ttl: null,
     });
     expect(result).not.toBeNull();
     expect(result?.value).toEqual(value);
@@ -69,7 +66,6 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      ttl: 1000,
     });
     await t.run(async (ctx) => {
       const metadata = await ctx.db.query("metadata").collect();
@@ -91,7 +87,6 @@ fcTest.prop({ key: fc.array(fc.string()), value: fc.array(fc.float()) })(
     const result = await t.mutation(api.cache.get, {
       name: "test",
       args: { key },
-      ttl: null,
     });
     expect(result).toBeNull();
   }

--- a/src/component/crons.ts
+++ b/src/component/crons.ts
@@ -1,6 +1,6 @@
 import { cronJobs } from "convex/server";
-import { api, internal } from "./_generated/api";
-import { internalMutation, mutation, MutationCtx } from "./_generated/server";
+import { api } from "./_generated/api";
+import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 
 const crons = cronJobs();
@@ -10,44 +10,30 @@ export const purge = mutation({
     expiresAt: v.optional(v.float64()),
   },
   returns: v.null(),
-  handler: purgeInner,
-});
-
-async function purgeInner(
-  ctx: MutationCtx,
-  { expiresAt }: { expiresAt?: number }
-) {
-  const valuesToDelete = await ctx.db
-    .query("expirations")
-    .withIndex(
-      "expiresAt",
-      expiresAt ? (q) => q.lte("expiresAt", expiresAt!) : undefined
-    )
-    .order("desc")
-    .take(100);
-  const deletions = [];
-  for (const value of valuesToDelete) {
-    deletions.push(ctx.db.delete(value._id));
-    deletions.push(ctx.db.delete(value.valueId));
-  }
-  await Promise.all(deletions);
-  if (valuesToDelete.length === 100) {
-    console.log("More than 100 values to delete, scheduling another purge");
-    await ctx.scheduler.runAfter(0, api.crons.purge, {
-      expiresAt: expiresAt ? valuesToDelete[99].expiresAt : undefined,
-    });
-  } else {
-    console.log("Purge complete");
-  }
-}
-
-crons.interval("expire", { hours: 24 }, internal.crons.expire);
-
-export const expire = internalMutation({
-  args: {},
-  handler: async (ctx) => {
-    await purgeInner(ctx, { expiresAt: Date.now() });
+  handler: async (ctx, args) => {
+    const expiresAt = args.expiresAt ?? Date.now();
+    const valuesToDelete = await ctx.db
+      .query("metadata")
+      .withIndex("expiresAt", (q) => q.lte("expiresAt", expiresAt!))
+      .order("desc")
+      .take(100);
+    const deletions = [];
+    for (const value of valuesToDelete) {
+      deletions.push(ctx.db.delete(value._id));
+      deletions.push(ctx.db.delete(value.valueId));
+    }
+    await Promise.all(deletions);
+    if (valuesToDelete.length === 100) {
+      console.debug("More than 100 values to delete, scheduling another purge");
+      await ctx.scheduler.runAfter(0, api.crons.purge, {
+        expiresAt: expiresAt ? valuesToDelete[99].expiresAt : undefined,
+      });
+    } else if (valuesToDelete.length > 0) {
+      console.debug("Cache purge complete");
+    }
   },
 });
+
+crons.interval("expire", { hours: 24 }, api.crons.purge, {});
 
 export default crons;

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -8,7 +8,7 @@ export const fetch = action({
     fn: v.string(),
     name: v.string(),
     args: v.any(),
-    expiration: v.union(v.float64(), v.null()),
+    ttl: v.union(v.float64(), v.null()),
   },
   returns: v.any(),
   handler: async (ctx, args): Promise<unknown> => {
@@ -17,8 +17,7 @@ export const fetch = action({
     if (cached !== null) return cached.value;
 
     const value = await ctx.runAction(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      fn as FunctionHandle<"action", any, any>,
+      fn as FunctionHandle<"action">,
       args.args
     );
     await ctx.runMutation(api.cache.put, { ...rest, value });
@@ -39,8 +38,8 @@ export const remove = mutation({
       .unique();
 
     if (!match) return null;
-    if (match.expirationId) {
-      await ctx.db.delete(match.expirationId);
+    if (match.metadataId) {
+      await ctx.db.delete(match.metadataId);
     }
     await ctx.db.delete(match._id);
   },
@@ -65,8 +64,8 @@ export const removeAll = mutation({
         : ctx.db.query("values");
     const matches = await query.order("desc").take(100);
     for (const match of matches) {
-      if (match.expirationId) {
-        await ctx.db.delete(match.expirationId);
+      if (match.metadataId) {
+        await ctx.db.delete(match.metadataId);
       }
       await ctx.db.delete(match._id);
     }

--- a/src/component/public.ts
+++ b/src/component/public.ts
@@ -55,13 +55,11 @@ export const removeAll = mutation({
     const { name, before } = args;
     const query = name
       ? ctx.db.query("values").withIndex("key", (q) => q.eq("name", name))
-      : before
-        ? ctx.db
-            .query("values")
-            .withIndex("by_creation_time", (q) =>
-              q.lte("_creationTime", before)
-            )
-        : ctx.db.query("values");
+      : ctx.db
+          .query("values")
+          .withIndex("by_creation_time", (q) =>
+            q.lte("_creationTime", before ?? Date.now())
+          );
     const matches = await query.order("desc").take(100);
     for (const match of matches) {
       if (match.metadataId) {
@@ -73,7 +71,7 @@ export const removeAll = mutation({
       await ctx.scheduler.runAfter(
         0,
         api.public.removeAll,
-        "name" in args ? { name } : { before: matches[99]._creationTime }
+        name ? { name } : { before: matches[99]._creationTime }
       );
     }
   },

--- a/src/component/schema.ts
+++ b/src/component/schema.ts
@@ -6,9 +6,9 @@ export default defineSchema({
     name: v.string(),
     args: v.any(),
     value: v.any(),
-    expirationId: v.optional(v.id("expirations")),
+    metadataId: v.optional(v.id("metadata")),
   }).index("key", ["name", "args"]),
-  expirations: defineTable({
+  metadata: defineTable({
     valueId: v.id("values"),
     expiresAt: v.float64(),
   }).index("expiresAt", ["expiresAt"]),


### PR DESCRIPTION
<!-- Describe your PR here. -->

- change purge to always be time based - undefined doesn't have special behavior. Just start with now.
- surface the "before" arg to delete really old entries (escape hatch for if they didn't have a ttl)
- always do an insert on `put` so creation time reflects generation time for now (patch isn't much more efficient anyways)- `cache.put` also always reflects the given ttl (though the public `fetch` doesn't)
- add/update tests

<!--
  The following applies to third-party contributors.
  Convex employees and contractors can delete or ignore.
-->

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
